### PR TITLE
Fix name of env var

### DIFF
--- a/postgrest/README.md
+++ b/postgrest/README.md
@@ -3,7 +3,7 @@
 ## env vars
 ```
 DB_URI=postgres://postgres:postgres@postgres:5432/postgres
-DB_SCHEMA=public
+PGSCHEMA=public
 DB_ANON_ROLE=postgres
 DB_POOL=10
 DB_MAXROWS=1000


### PR DESCRIPTION
Not sure why this one's named with a different convention, but this is the name of the env var in `Dockerfile` and `entrypoint.sh`.